### PR TITLE
Downloads related to Package (not to Release)

### DIFF
--- a/core/components/modxrepository/processors/rest/download/index.class.php
+++ b/core/components/modxrepository/processors/rest/download/index.class.php
@@ -57,7 +57,7 @@ class modxRepositoryDownload extends modxRepositoryResponse{
         // Count downloads
         if(
             !empty($package['r_content_id'])
-            AND $resource = $this->modx->getObject('modResource', $package['r_content_id'])
+            AND $resource = $this->modx->getObject('modResource', $package['id'])
         ){
             $count = (int)$resource->getTVValue('downloads');
             $resource->setTVValue('downloads', $count + 1);


### PR DESCRIPTION
По-моему, считать загрузки надо у самого компонента, а не у каждого выпуска в отдельности. Иначе счетчик загрузок будет обнуляться при выпуске новой версии
